### PR TITLE
[GLM-5413] Plugin reworked

### DIFF
--- a/gleam.php
+++ b/gleam.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gleam
  * Plugin URI: https://gleam.io/docs/faq#wordpress
  * Description: Gleam competition plugin. Requires PHP 5.3
- * Version: 1.0
+ * Version: 2.0
  * Author: Crowd9
  * Author URI: https://github.com/Crowd9/Gleam-Wordpress
  */

--- a/gleam.php
+++ b/gleam.php
@@ -10,8 +10,7 @@
 
 
 function gleam_init() {
-    $file = file_get_contents('https://js.gleam.io/e.js');
-    echo "<script>$file</script>";
+    echo '<script src="//js.gleam.io/e.js" async="true"></script>';
 }
 
 function gleam_shortcode($atts, $content = null) {

--- a/gleam.php
+++ b/gleam.php
@@ -1,21 +1,36 @@
 <?php
 /**
  * Plugin Name: Gleam
- * Plugin URI: https://gleam.io/
+ * Plugin URI: https://gleam.io/docs/faq#wordpress
  * Description: Gleam competition plugin. Requires PHP 5.3
  * Version: 1.0
  * Author: Crowd9
  * Author URI: https://github.com/Crowd9/Gleam-Wordpress
  */
 
-add_shortcode('gleam', function($atts, $content = null) {
+
+function gleam_init() {
+    $file = file_get_contents('https://js.gleam.io/e.js');
+    echo "<script>$file</script>";
+}
+
+function gleam_shortcode($atts, $content = null) {
     $args = shortcode_atts(array(
         'url' => null
     ), $atts);
-    
+  
     if (empty($args['url'])) {
         return;
     }
-    return sprintf('<a class="e-gleam" href="%s" rel="nofollow">%s</a><script src="//js.gleam.io/e.js" async="true"></script>',
-            htmlspecialchars($args['url']), do_shortcode($content));
-});
+  
+    return 
+        sprintf(
+            '<a class="e-gleam" href="%s" rel="nofollow">%s</a>',
+            htmlspecialchars($args['url']),
+            do_shortcode($content)
+        );
+}
+
+add_filter('wp_footer', 'gleam_init');
+
+add_shortcode('gleam', 'gleam_shortcode');

--- a/readme.txt
+++ b/readme.txt
@@ -3,4 +3,4 @@ Gleam-Wordpress
 
 Widget shortcode example:
 
-[gleam_widget url="https://gleam.io/iR0GQ/gleam-demo-competition"]Gleam Demo Competition[/gleam_widget]
+[gleam url="https://gleam.io/iR0GQ/gleam-demo-competition"]Gleam Demo Competition[/gleam]


### PR DESCRIPTION
## Change description
Some users complaint that they can't access Gleam wordpress plugin. This is caused by ad block, blocking the script to https://js.gleam.io/e.js so the plugin won't work.

The solution I proposed is to fetch https://js.gleam.io/e.js through backend and render it from server side through <script> tag at the footer of the page (Before body tag closes).

Other solution is to move https://js.gleam.io/e.js to another repository. But by doing so, will break existing website.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/80539853/228434352-b36232d3-63b1-4f24-9de6-10997f92f220.png">

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
> Update Wordpress Plugin [GLM-5413](https://linear.app/gleamio/issue/GLM-5413) 

## Testing
Check the demo here https://jerryteststuff.000webhostapp.com/2023/03/hello-world
- Install wordpress locally.
- Install gleam plugin from plugin store.
- Install adblock.
- Plugin does not work because https://js.gleam.io/e.js is being blocked by adblock
- Disable adblock
- Plugin work and is able to access https://js.gleam.io/e.js
- Tried to render https://js.gleam.io/e.js through server side using file_get_contents
- Enable adblock
- Plugin still work because it no longer called https://js.gleam.io/e.js from frontend

## Checklists
- [x] Tested locally
- [ ] Tested on shared hosting

### Development
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security
- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 
- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
